### PR TITLE
fix for TimeoutError

### DIFF
--- a/rose/uv_events.py
+++ b/rose/uv_events.py
@@ -30,6 +30,9 @@ if sys.platform == 'win32':
 # Argument for default thread pool executor creation.
 _MAX_WORKERS = 5
 
+def _raise_stop_error():
+    raise _StopError
+
 
 class EventLoop(events.AbstractEventLoop):
 
@@ -89,7 +92,7 @@ class EventLoop(events.AbstractEventLoop):
         if timeout is None:
             timeout = 0x7fffffff/1000.0  # 24 days
         future.add_done_callback(lambda _: self.stop())
-        handler = self.call_later(timeout, lambda _: self.stop())
+        handler = self.call_later(timeout, _raise_stop_error)
         self.run()
         handler.cancel()
         if future.done():


### PR DESCRIPTION
without this code, i always get TimeoutError in run_until_complete. otherwise everything works fine

```
Traceback (most recent call last):
  File "/Users/nikolay/dev/tulip/src/gunicorn/gunicorn/arbiter.py", line 485, in spawn_worker
    worker.init_process()
  File "/Users/nikolay/dev/tulip/src/gtulip/gtulip/worker.py", line 29, in init_process
    super().init_process()
  File "/Users/nikolay/dev/tulip/src/gunicorn/gunicorn/workers/base.py", line 104, in init_process
    self.run()
  File "/Users/nikolay/dev/tulip/src/gtulip/gtulip/worker.py", line 32, in run
    return self.ev_loop.run_until_complete(tulip.Task(self._run()))
  File "/Users/nikolay/dev/tulip/src/tulip/tulip/uv_events.py", line 98, in run_until_complete
    raise futures.TimeoutError
concurrent.futures._base.TimeoutError
```
