### PR TITLE
Fix `AttributeError` in `EventLoop.run_forever`.

### DIFF
--- a/aiouv/_events.py
+++ b/aiouv/_events.py
@@ -52,6 +52,7 @@ class EventLoop(base_events.BaseEventLoop):
         self._loop._rose_loop = self
         self._default_executor = None
         self._last_exc = None
+        self._running = False
 
         self._fd_map = {}
         self._signal_handlers = {}


### PR DESCRIPTION
Now that I look at the history of the file, I'm pretty sure it only ever worked because `BaseEventLoop` already had an attribute named `_running`. Sadly, that's not true anymore.

```
+0 # cat ../CPython/Lib/asyncio/*.py | grep '\._running'
+1 # cat ../CPython/README | head -n 1
This is Python version 3.5.0 alpha 4
```

(Sorry for saying that the bindings suck, by the way.) :-)