### PR TITLE
Fix `AttributeError` in `EventLoop.close`

### DIFF
--- a/aiouv/_events.py
+++ b/aiouv/_events.py
@@ -103,6 +103,7 @@ class EventLoop(base_events.BaseEventLoop):
 
         del self._loop._rose_loop
         self._loop = None
+        super().close()
 
     def is_running(self):
         return self._running


### PR DESCRIPTION
Ubuntu 15.04. python3.5.0 (from deadsnakes ppa).

I got traceback at script exit:

```
/usr/lib/python3.5/asyncio/base_events.py:385: ResourceWarning: unclosed event loop <EventLoop running=False closed=False debug=True>
Exception ignored in: <bound method BaseEventLoop.__del__ of <EventLoop running=False closed=False debug=True>>
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/base_events.py", line 387, in __del__
  File "/tmp/python/lib/python3.5/site-packages/aiouv/_events.py", line 96, in close
AttributeError: 'NoneType' object has no attribute 'handles'
```

How to repoduce:

```
import aiouv
loop = aiouv.EventLoop()
loop.close()
print("Stopped!")
```

EventLoop.close() method was called twice here. In the first case it called from the script and in the second case indirectly at script exit. 

It seems the calling close() method from the parent class fixes this issue. I'm not sure of correctness of what.
